### PR TITLE
fix: remove invalid line from app.ts

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,6 @@ import cookieParser from 'cookie-parser';
 import authRouter from './auth/auth.router.js';
 
 const app = express();
-com.huhygwyguywi
 
 app.use(express.json());
 app.use(cookieParser());


### PR DESCRIPTION
## Summary
- Removes the erroneous `com.huhygwyguywi` statement on line 7 of `src/app.ts` introduced in commit `4a7fd59`
- The invalid line caused a runtime error and would prevent the Express app from starting

## Test plan
- [ ] Run `npx tsx src/app.ts` (or the server entry point) and verify it starts without errors
- [ ] Hit `GET /health` and confirm `{ status: 'ok' }` is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)