### PR TITLE
feat: trigger Claude on commit comment @mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,8 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  commit_comment:
+    types: [created]
 
 jobs:
   claude:
@@ -16,10 +18,11 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'commit_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
       issues: read
       id-token: write


### PR DESCRIPTION
## Summary
- Adds `commit_comment` event trigger to the Claude Code workflow
- Claude now activates when `@claude` is mentioned in a GitHub commit comment
- Bumps `contents` permission from `read` to `write` so Claude can post reply comments on commits

## Test plan
- [ ] Navigate to any commit on GitHub
- [ ] Leave a comment containing `@claude`
- [ ] Verify the Claude Code workflow is triggered in the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)