### PR TITLE
fix: resolve CI typecheck failure and claude-review config warning

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
+      - run: npx prisma generate
       - run: npx tsc --noEmit
 
   claude-review:
@@ -34,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_prompt: |
+          prompt: |
             Review the changes in this pull request for correctness, bugs, and code quality.
             Focus on: syntax errors, logic errors, security issues, and TypeScript type safety.
             Post inline comments on specific lines where issues are found.


### PR DESCRIPTION
## Summary
- Add `npx prisma generate` before `npx tsc --noEmit` in the typecheck job — the generated Prisma client (`generated/prisma/`) is gitignored, so CI was failing with `Cannot find module` errors on every PR
- Rename `direct_prompt` → `prompt` in the `claude-review` job to match the valid input name for `anthropics/claude-code-action@v1`

## Test plan
- [ ] Typecheck job passes without `TS2307` module-not-found errors
- [ ] Claude review job runs without the `Unexpected input(s) 'direct_prompt'` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)